### PR TITLE
Adição de logradouro e abreviação

### DIFF
--- a/Rules_Brazilian-Specific.validator.mapcss
+++ b/Rules_Brazilian-Specific.validator.mapcss
@@ -23,12 +23,12 @@ relation[highway][name =~ /\b[A-Z]{2,3} (- )?[0-9]{2,3}\b/] {
 
 /* nome de vias sem logradouro correto */
 way[highway=cycleway][name][name !~ /^(?i)ciclovia .*/],
-way[highway][highway !~ /bridleway|bus_stop|cycleway|crossing|footway|give_way|motorway_junction|path|raceway|rest_area|services|speed_camera|steps|stop/][name][name !~ /^(Aeroporto|Alameda|Área|Avenida|([1-9][0-9]?º )?Beco|Campo|Chácara|Colônia|Condomínio|Conjunto|Contorno|Distrito|Esplanada|Estação|Estrada|Favela|Fazenda|Feira|Jardim|Ladeira|Lago|Lagoa|Largo|Loteamento|Morro|Núcleo|([1-9][0-9]?ª )?Paralela|Parque|Passarela|Pátio|Ponte|Praça|Quadra|Recanto|Residencial|Rodoanel|Rodovia|Rotatória|Rua|Setor|Sítio|([1-9][0-9]?ª )?Subida|([1-9][0-9]?ª )?Travessa|Trecho|Trevo|Túnel|Vale|Vereda|Via|Viadutos?|Viela|Vila|(Anel|Complexo|Dispositivo) (Rodo)?(V|v)iário) .*/] {
+way[highway][highway !~ /bridleway|bus_stop|cycleway|crossing|footway|give_way|motorway_junction|path|raceway|rest_area|services|speed_camera|steps|stop/][name][name !~ /^(Aeroporto|Alameda|Área|Avenida|([1-9][0-9]?º )?Beco|Boulevard|Campo|Chácara|Colônia|Condomínio|Conjunto|Contorno|Distrito|Esplanada|Estação|Estrada|Favela|Fazenda|Feira|Jardim|Ladeira|Lago|Lagoa|Largo|Loteamento|Morro|Núcleo|([1-9][0-9]?ª )?Paralela|Parque|Passarela|Pátio|Ponte|Praça|Quadra|Recanto|Residencial|Rodoanel|Rodovia|Rotatória|Rua|Setor|Sítio|([1-9][0-9]?ª )?Subida|([1-9][0-9]?ª )?Travessa|Trecho|Trevo|Túnel|Vale|Vereda|Via|Viadutos?|Viela|Vila|(Anel|Complexo|Dispositivo) (Rodo)?(V|v)iário) .*/] {
 	throwWarning: tr("{0} com logradouro ausente, errado ou abreviado", "{0.key}");
 }
 
 /* endereços sem logradouro correto */
-*["addr:street"]["addr:street" !~ /^(Aeroporto|Alameda|Área|Avenida|([1-9][0-9]?º )?Beco|Campo|Chácara|Colônia|Condomínio|Conjunto|Contorno|Distrito|Esplanada|Estação|Estrada|Favela|Fazenda|Feira|Jardim|Ladeira|Lago|Lagoa|Largo|Loteamento|Morro|Núcleo|([1-9][0-9]?ª )?Paralela|Parque|Passarela|Pátio|Ponte|Praça|Quadra|Recanto|Residencial|Rodovia|Rotatória|Rua|Setor|Sítio|([1-9][0-9]?ª )?Subida|([1-9][0-9]?ª )?Travessa|Trecho|Trevo|Túnel|Vale|Vereda|Via|Viadutos?|Viela|Vila|(Anel|Complexo|Dispositivo) (Rodo)?(V|v)iário) .*/] {
+*["addr:street"]["addr:street" !~ /^(Aeroporto|Alameda|Área|Avenida|([1-9][0-9]?º )?Beco|Boulevard|Campo|Chácara|Colônia|Condomínio|Conjunto|Contorno|Distrito|Esplanada|Estação|Estrada|Favela|Fazenda|Feira|Jardim|Ladeira|Lago|Lagoa|Largo|Loteamento|Morro|Núcleo|([1-9][0-9]?ª )?Paralela|Parque|Passarela|Pátio|Ponte|Praça|Quadra|Recanto|Residencial|Rodovia|Rotatória|Rua|Setor|Sítio|([1-9][0-9]?ª )?Subida|([1-9][0-9]?ª )?Travessa|Trecho|Trevo|Túnel|Vale|Vereda|Via|Viadutos?|Viela|Vila|(Anel|Complexo|Dispositivo) (Rodo)?(V|v)iário) .*/] {
 	throwWarning: tr("{0} com logradouro ausente, errado ou abreviado", "{0.key}");
 }
 
@@ -51,7 +51,7 @@ way[highway = track][name][name =~ /^(?i)(?u)(alameda|avenida|beco|estrada|ladei
 }
 
 /* palavras abreviadas */
-*[name =~ /(?i)(^|.* )(Cel|Dª|Dr|Eng|Gov|Jr|Marg|Mun|p\/|Pde|Pe|Pst|Pref|Profa|Profª|Prof|s\/|Sr(a|ª)?|Sta|Sto|Ver)\.? .*/] {
+*[name =~ /(?i)(^|.* )(Cel|Cmte|Dª|Dr|Eng|Gov|Jr|Marg|Mun|p\/|Pde|Pe|Pst|Pref|Profa|Profª|Prof|s\/|Sr(a|ª)?|Sta|Sto|Ver)\.? .*/] {
 	throwWarning: tr("palavra abreviada em {0}", "{0.key}");
 }
 


### PR DESCRIPTION
+ Adição do logradouro “**Boulevard**”
<br />Exemplo: Boulevar Castilhos França, Belém, PA
+ Adição da abreviação “**Cmte**” (Comandante)
<br />Exemplo: Avenida Comandante Brás de Aguiar, Belém, PA