### PR TITLE
Testes/correção para CNPJ e posto de saúde como hospital.

### DIFF
--- a/Rules_Brazilian-Specific.validator.mapcss
+++ b/Rules_Brazilian-Specific.validator.mapcss
@@ -369,6 +369,8 @@ relation[tag("power") = parent_tag("power")] ∈ *[power][inside("BR")] {
 
 *[name =~ /^(?i)(?u)(AM(A|E)|(Posto|Unidade (Básica)?) de Sa(u|ú)de|UBS|PSF).*/][amenity = hospital][inside("BR")] {
 	throwWarning: tr("postos/unidades de saúde devem ser amenity=clinic");
+	fixAdd: "amenity=clinic";
+	group: tr("Brasil - Correções e melhorias");
 }
 
 *[name =~ /^(?i)\bSAMU\b/][amenity =~ /clinic|doctors|hospital/][inside("BR")] {

--- a/Rules_Brazilian-Specific.validator.mapcss
+++ b/Rules_Brazilian-Specific.validator.mapcss
@@ -1054,3 +1054,23 @@ area[place = square][leisure != park][inside("BR")] {
 	suggestAlternative: "leisure=bandstand";
 	group: tr("Brasil - Verificar");
 }
+
+/* Alerta para CNPJ diferente de BRxxxxxxxxxxxxxx */
+*["ref:vatin"]["ref:vatin" !~ /^BR[0-9]{14}$/][inside("BR")]  {
+	throwWarning: tr("CNPJ diferente do formato BRxxxxxxxxxxxxxx");
+	group: tr("Brasil - Verificar");
+}
+
+/* Correção para CNPJ: xx.xxx.xxx/xxxx-xx => BRxxxxxxxxxxxxxx */
+*["ref:vatin" =~ /^[0-9]{2}\.[0-9]{3}\.[0-9]{3}\/[0-9]{4}-[0-9]{2}$/][inside("BR")] {
+	throwWarning: tr("formato do CNPJ pode ser melhorado em {0}", "{0.key}");
+	fixAdd: concat("ref:vatin=BR", replace(replace(replace(tag("ref:vatin"), "/", ""), ".", ""), "-", ""));
+	group: tr("Brasil - Correções e melhorias");
+}
+
+/* Correção para CNPJ: (br|bR|Br)xxxxxxxxxxxxxx => BRxxxxxxxxxxxxxx */
+*["ref:vatin" =~ /^(br|bR|Br)[0-9]{14}$/][inside("BR")]  {
+	throwWarning: tr("CNPJ deve iniciar maiúsculo: BRxxxxxxxxxxxxxx");
+	fixAdd: concat("ref:vatin=", upper(tag("ref:vatin")));
+	group: tr("Brasil - Correções e melhorias");
+}


### PR DESCRIPTION
Adiciona fixadd ao teste de postos de saúde tagueados como hospital.

Adiciona teste para ref:vatin diferente de BR[0-9]{14}.

Adiciona correções para as possibilidades de ref:vatin:
xx.xxx.xxx/xxxx-xx => BRxxxxxxxxxxxxxx
(br|bR|Br)xxxxxxxxxxxxxx => BRxxxxxxxxxxxxxx